### PR TITLE
Make compatible with pyspark.ml.linalg.Vector type

### DIFF
--- a/caikit/interfaces/ts/data_model/backends/pandas_backends.py
+++ b/caikit/interfaces/ts/data_model/backends/pandas_backends.py
@@ -25,6 +25,7 @@ from .base import (
     TimeSeriesBackendBase,
     UncachedBackendMixin,
 )
+from ..toolkit.optional_dependencies import HAVE_PYSPARK
 from .util import iteritems_workaround, pd_timestamp_to_seconds
 from caikit.core.data_model import DataBase, ProducerId
 from caikit.core.toolkit.errors import error_handler
@@ -149,7 +150,7 @@ class PandasTimeSeriesBackend(TimeSeriesBackendBase):
     """The PandasTimeSeriesBackend is responsible for managing the standard
     in-memory representation of a TimeSeries
     """
-
+    
     def __init__(
         self,
         data_frame: pd.DataFrame,
@@ -303,6 +304,15 @@ class PandasValueSequenceBackend(UncachedBackendMixin, StrictFieldBackendMixin):
 
     # This dtype is what shows up for non-periodic date ranges
     _TIMESTAMP_DTYPE = np.dtype("datetime64[ns]")
+    
+    # What types do we consider to be vector types
+    _DEFAULT_VECTOR_TYPES = [list, np.ndarray]
+    if HAVE_PYSPARK:
+        # pyspark.pandas.DataFrame objects can contain
+        # pyspark specific objects
+        import pyspark
+        from pyspark.ml.linalg import Vector as SVector
+        _DEFAULT_VECTOR_TYPES.append(SVector)
 
     def __init__(self, data_frame: pd.Series, col_name: str):
         """Initialize with the data frame and the value column name"""
@@ -331,7 +341,7 @@ class PandasValueSequenceBackend(UncachedBackendMixin, StrictFieldBackendMixin):
         #  serializable
         # this is making the assumption that we have at least one value in the dataframe
         elif str(self._dtype) == "object" and isinstance(
-            self._df[self._col_name].iloc[0], (list, np.ndarray)
+            self._df[self._col_name].iloc[0], tuple(PandasValueSequenceBackend._DEFAULT_VECTOR_TYPES)
         ):
             self._sequence_type = time_types.ValueSequence.VectorValueSequence
             self._valid_oneof = "val_vector"

--- a/caikit/interfaces/ts/data_model/backends/pandas_backends.py
+++ b/caikit/interfaces/ts/data_model/backends/pandas_backends.py
@@ -19,13 +19,13 @@ import alog
 
 # Local
 from .. import time_types
+from ..toolkit.optional_dependencies import HAVE_PYSPARK
 from .base import (
     MultiTimeSeriesBackendBase,
     StrictFieldBackendMixin,
     TimeSeriesBackendBase,
     UncachedBackendMixin,
 )
-from ..toolkit.optional_dependencies import HAVE_PYSPARK
 from .util import iteritems_workaround, pd_timestamp_to_seconds
 from caikit.core.data_model import DataBase, ProducerId
 from caikit.core.toolkit.errors import error_handler
@@ -150,7 +150,7 @@ class PandasTimeSeriesBackend(TimeSeriesBackendBase):
     """The PandasTimeSeriesBackend is responsible for managing the standard
     in-memory representation of a TimeSeries
     """
-    
+
     def __init__(
         self,
         data_frame: pd.DataFrame,
@@ -304,14 +304,16 @@ class PandasValueSequenceBackend(UncachedBackendMixin, StrictFieldBackendMixin):
 
     # This dtype is what shows up for non-periodic date ranges
     _TIMESTAMP_DTYPE = np.dtype("datetime64[ns]")
-    
+
     # What types do we consider to be vector types
     _DEFAULT_VECTOR_TYPES = [list, np.ndarray]
     if HAVE_PYSPARK:
         # pyspark.pandas.DataFrame objects can contain
         # pyspark specific objects
-        import pyspark
+        # Third Party
         from pyspark.ml.linalg import Vector as SVector
+        import pyspark
+
         _DEFAULT_VECTOR_TYPES.append(SVector)
 
     def __init__(self, data_frame: pd.Series, col_name: str):
@@ -341,7 +343,8 @@ class PandasValueSequenceBackend(UncachedBackendMixin, StrictFieldBackendMixin):
         #  serializable
         # this is making the assumption that we have at least one value in the dataframe
         elif str(self._dtype) == "object" and isinstance(
-            self._df[self._col_name].iloc[0], tuple(PandasValueSequenceBackend._DEFAULT_VECTOR_TYPES)
+            self._df[self._col_name].iloc[0],
+            tuple(PandasValueSequenceBackend._DEFAULT_VECTOR_TYPES),
         ):
             self._sequence_type = time_types.ValueSequence.VectorValueSequence
             self._valid_oneof = "val_vector"

--- a/caikit/interfaces/ts/data_model/backends/util.py
+++ b/caikit/interfaces/ts/data_model/backends/util.py
@@ -8,6 +8,9 @@ from typing import Any, Iterable, List, Union
 import numpy as np
 import pandas as pd
 
+# Local
+from ...data_model.toolkit.optional_dependencies import HAVE_PYSPARK, pyspark
+
 
 def mock_pd_groupby(a_df_like, by: List[str], return_pandas_api=False):
     """Roughly mocks the behavior of pandas groupBy but on a spark dataframe."""
@@ -124,6 +127,14 @@ def iteritems_workaround(series: Any, force_list: bool = False) -> Iterable:
 
     if isinstance(series, pd.Series):
         return series
+
+    # handle an edge case of pyspark.ml.linalg.DenseVector
+    if HAVE_PYSPARK:
+        if isinstance(series, pyspark.pandas.series.Series) and isinstance(
+            series[0], pyspark.ml.linalg.DenseVector
+        ):
+            return [x.values.tolist() for x in series.to_numpy()]
+
 
     # note that we're forcing a list only if we're not
     # a native pandas series

--- a/caikit/interfaces/ts/data_model/backends/util.py
+++ b/caikit/interfaces/ts/data_model/backends/util.py
@@ -131,10 +131,9 @@ def iteritems_workaround(series: Any, force_list: bool = False) -> Iterable:
     # handle an edge case of pyspark.ml.linalg.DenseVector
     if HAVE_PYSPARK:
         if isinstance(series, pyspark.pandas.series.Series) and isinstance(
-            series[0], pyspark.ml.linalg.DenseVector
+            series[0], pyspark.ml.linalg.Vector
         ):
-            return [x.values.tolist() for x in series.to_numpy()]
-
+            return [x.toArray().tolist() for x in series.to_numpy()]
 
     # note that we're forcing a list only if we're not
     # a native pandas series


### PR DESCRIPTION
This PR adds support for serialization of pyspark.ml.linalg.Vector types in the timeseries data model. This type can appear as the output of some pyspark.ml estimators.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
